### PR TITLE
Use static FileAccess on node doc path

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -977,7 +977,7 @@ func show_library_item_doc() -> void:
 		var doc_name = library.get_selected_item_doc_name()
 		while doc_name != "":
 			var doc_path : String = doc_dir+"/node_"+doc_name+".html"
-			if DirAccess.open("res://").file_exists(doc_path):
+			if FileAccess.file_exists(doc_path):
 				OS.shell_open(doc_path)
 				break
 			doc_name = doc_name.left(doc_name.rfind("_"))


### PR DESCRIPTION
Since we're using an absolute file path for the node documentation, the static `FileAccess` should be used.
Previously, documentation was being searched inside of "//res" which made it not work on release.
This PR should fix [Issue #768](https://github.com/RodZill4/material-maker/issues/768) on future releases.